### PR TITLE
Add workflow to publish Docker image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,63 @@
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image version tag'
+        required: true
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+
+      - name: Build and push Docker image
+        run: |
+          IMAGE_ID=${{ env.REGISTRY }}/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          VERSION=${{ env.VERSION }}
+          docker build . -t "${IMAGE_ID}:${VERSION}"
+          if [ "${VERSION}" != "latest" ]; then
+            docker tag "${IMAGE_ID}:${VERSION}" "${IMAGE_ID}:latest"
+          fi
+          docker push "${IMAGE_ID}:${VERSION}"
+          if [ "${VERSION}" != "latest" ]; then
+            docker push "${IMAGE_ID}:latest"
+          fi
+
+      - name: Create or update GitHub Release
+        if: ${{ env.VERSION != 'latest' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ env.VERSION }}"
+          TITLE="Release ${TAG}"
+          NOTES="Automated release for version ${{ env.VERSION }}."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TITLE" --notes "$NOTES"
+          else
+            gh release create "$TAG" --title "$TITLE" --notes "$NOTES"
+          fi


### PR DESCRIPTION
## Summary
- add a workflow that publishes Docker images to GitHub Container Registry
- build images with the provided version tag and optionally update the latest tag
- create or update a GitHub release whenever a non-latest image tag is published

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d3c78390cc8325bb6c28714a812e02